### PR TITLE
Add cryptography==41.0.3 hash

### DIFF
--- a/overrides/default.nix
+++ b/overrides/default.nix
@@ -395,6 +395,7 @@ lib.composeManyExtensions [
             "40.0.2" = "sha256-cV4GTfbVYanElXOVmynvrru2wJuWvnT1Z1tQKXdkbg0=";
             "41.0.1" = "sha256-38q81vRf8QHR8lFRM2KbH7Ng5nY7nmtWRMoPWS9VO/U=";
             "41.0.2" = "sha256-hkuoICa/suMXlr4u95JbMlFzi27lJqJRmWnX3nZfzKU=";
+            "41.0.3" = "sha256-LQu7waympGUs+CZun2yDQd2gUUAgyisKBG5mddrfSo0=";
           }.${version} or (
             lib.warn "Unknown cryptography version: '${version}'. Please update getCargoHash." lib.fakeHash
           );


### PR DESCRIPTION
Adds the build hash for the cryptography dependency